### PR TITLE
class Object 是 php7.2 里面官方类，不可以再使用，需要改成BaseObject

### DIFF
--- a/wrapper/yii2-ext/Database.php
+++ b/wrapper/yii2-ext/Database.php
@@ -10,7 +10,7 @@
  */
 namespace hightman\xunsearch;
 
-use yii\base\Object;
+use yii\base\BaseObject;
 
 /**
  * xunsearch Database is used to wrapper XS class
@@ -24,7 +24,7 @@ use yii\base\Object;
  * @author hightman <hightman@twomice.net>
  * @since 1.4.9
  */
-class Database extends Object
+class Database extends BaseObject
 {
 	public $iniFile;
 	public $charset;


### PR DESCRIPTION
class Object 是 php7.2 里面官方类，不可以再使用，需要改成BaseObject